### PR TITLE
upgraded default version of Oracle Linux to 8

### DIFF
--- a/datasources.tf
+++ b/datasources.tf
@@ -29,7 +29,11 @@ data "oci_core_vcn" "vcn" {
 data "template_file" "oracle_template" {
   template = file("${path.module}/scripts/operator.template.sh")
 
-  count = (var.operator_enabled == true && var.operator_image_id == "Oracle") ? 1 : 0
+  vars = {
+    ol = var.operating_system_version
+  }
+
+  count = (var.operator_enabled == true) ? 1 : 0
 }
 
 data "template_file" "oracle_cloud_init_file" {
@@ -41,13 +45,13 @@ data "template_file" "oracle_cloud_init_file" {
     timezone            = var.timezone
   }
 
-  count = (var.operator_enabled == true && var.operator_image_id == "Oracle") ? 1 : 0
+  count = (var.operator_enabled == true) ? 1 : 0
 }
 
 data "oci_core_images" "oracle_images" {
   compartment_id           = var.compartment_id
   operating_system         = "Oracle Linux"
-  operating_system_version = "7.9"
+  operating_system_version = var.operating_system_version
   shape                    = lookup(var.operator_shape, "shape", "VM.Standard.E2.2")
   sort_by                  = "TIMECREATED"
 }

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -152,11 +152,15 @@ Ensure you review the {uri-terraform-dependencies}[dependencies].
   memory=4,
   boot_volume_size=50
 }`
-
 |`operator_upgrade`
 |Whether to upgrade the operator host packages after provisioning. It's useful to set this to false during development/testing so the operator is provisioned faster.
 |true/false
 |true
+
+|`operating_system_version`
+|The version of the Oracle Linux to use..
+|
+|8
 
 |`ssh_public_key`
 |the content of the ssh public key used to access the operator. set this or the ssh_public_key_path

--- a/scripts/operator.template.sh
+++ b/scripts/operator.template.sh
@@ -3,15 +3,12 @@
 # Copyright 2017, 2019, Oracle Corporation and/or affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-# yum update --security
+if [ ${ol} = 8 ]; then
+  dnf -y upgrade --security
+else
+  yum -y -t update --security
+fi
 
-# sed -i -e "s/autoinstall\s=\sno/# autoinstall = yes/g" /etc/uptrack/uptrack.conf
-
-# uptrack-upgrade
-
-# pip3 install oci-cli
-
-yum -y -t update --security
-sed -i -e "s/autoinstall\s=\sno/# autoinstall = yes/g" /etc/uptrack/uptrack.conf
+sed -i -e "s/autoinstall\s=\sno/autoinstall = yes/g" /etc/uptrack/uptrack.conf
 uptrack-upgrade -y
 pip3 install oci-cli

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -47,6 +47,8 @@ operator_shape = {
   boot_volume_size=50
 }
 
+operating_system_version = "8"
+
 operator_upgrade = false
 
 ssh_public_key = ""

--- a/variables.tf
+++ b/variables.tf
@@ -109,6 +109,11 @@ variable "operator_shape" {
   type        = map(any)
 }
 
+variable "operating_system_version" {
+  description = "The version of the Oracle Linux to use."
+  default     = "8"
+  type        = string
+}
 variable "operator_upgrade" {
   description = "Whether to upgrade the operator host packages after provisioning. It's useful to set this to false during development/testing so the operator is provisioned faster."
   default     = false


### PR DESCRIPTION
* Added a new variable that would allow existing users to use Oracle
* Linux 7.9 for backward compatibility. Also removed superflous check
* on image id and updated docs.

Closes #26 