### PR TITLE
feat: Added Custom KMS support for boot volume encryption, support for in-transit encryption

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -7,12 +7,16 @@ resource "oci_core_instance" "operator" {
   agent_config {
 
     are_all_plugins_disabled = false
-    is_management_disabled   = true
+    is_management_disabled   = false
     is_monitoring_disabled   = false
 
     plugins_config {
       desired_state = "ENABLED"
       name          = "Bastion"
+    }
+    plugins_config {
+      desired_state = "DISABLED"
+      name          = "OS Management Service Agent"
     }
   }
   

--- a/compute.tf
+++ b/compute.tf
@@ -38,7 +38,7 @@ resource "oci_core_instance" "operator" {
     network_type     = "PARAVIRTUALIZED"
   }
 
-  # prevent the operator from destroying and recreating itself if the image ocid changes 
+  # prevent the operator from destroying and recreating itself if the image ocid changes
   lifecycle {
     ignore_changes = [source_details[0].source_id]
   }
@@ -61,6 +61,7 @@ resource "oci_core_instance" "operator" {
   source_details {
     source_type = "image"
     source_id   = local.operator_image_id
+    kms_key_id  = var.boot_volume_encryption_key
   }
 
   state = var.operator_state

--- a/compute.tf
+++ b/compute.tf
@@ -38,6 +38,7 @@ resource "oci_core_instance" "operator" {
     network_type     = "PARAVIRTUALIZED"
   }
 
+  is_pv_encryption_in_transit_enabled = var.enable_pv_encryption_in_transit
   # prevent the operator from destroying and recreating itself if the image ocid changes
   lifecycle {
     ignore_changes = [source_details[0].source_id]

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -123,7 +123,7 @@ Ensure you review the {uri-terraform-dependencies}[dependencies].
 |imageid/Oracle
 |Oracle
 
-|`is_pv_encryption_in_transit_enabled`
+|`enable_pv_encryption_in_transit`
 |Whether to enable in-transit encryption for the data volume's paravirtualized attachment
 |true/false
 |false

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -123,6 +123,11 @@ Ensure you review the {uri-terraform-dependencies}[dependencies].
 |imageid/Oracle
 |Oracle
 
+|`boot_volume_encryption_key`
+|The OCID of the OCI KMS key to assign as the master encryption key for the boot volume.
+|""
+|
+
 |`enable_operator_instance_principal`
 |Whether to enable instance_principal on the operator.
 |true/false

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -123,6 +123,11 @@ Ensure you review the {uri-terraform-dependencies}[dependencies].
 |imageid/Oracle
 |Oracle
 
+|`is_pv_encryption_in_transit_enabled`
+|Whether to enable in-transit encryption for the data volume's paravirtualized attachment
+|true/false
+|false
+
 |`boot_volume_encryption_key`
 |The OCID of the OCI KMS key to assign as the master encryption key for the boot volume.
 |""

--- a/variables.tf
+++ b/variables.tf
@@ -150,3 +150,9 @@ variable "operator_notification_topic" {
   default     = "operator"
   type        = string
 }
+
+variable "boot_volume_encryption_key" {
+  description = "The OCID of the OCI KMS key to assign as the master encryption key for the boot volume."
+  default     = ""
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -126,6 +126,18 @@ variable "upgrade_operator" {
   type        = bool
 }
 
+variable "enable_pv_encryption_in_transit" {
+  description = "Whether to enable in-transit encryption for the data volume's paravirtualized attachment. The default value is false"
+  default = false
+  type = bool
+}
+
+variable "boot_volume_encryption_key" {
+  description = "The OCID of the OCI KMS key to assign as the master encryption key for the boot volume."
+  default     = ""
+  type        = string
+}
+
 # operator notification
 variable "enable_operator_notification" {
   description = "Whether to enable ONS notification for the operator host."
@@ -151,14 +163,3 @@ variable "operator_notification_topic" {
   type        = string
 }
 
-variable "boot_volume_encryption_key" {
-  description = "The OCID of the OCI KMS key to assign as the master encryption key for the boot volume."
-  default     = ""
-  type        = string
-}
-
-variable "enable_pv_encryption_in_transit" {
-  description = "Whether to enable in-transit encryption for the data volume's paravirtualized attachment. The default value is false"
-  default = false
-  type = bool
-}

--- a/variables.tf
+++ b/variables.tf
@@ -156,3 +156,9 @@ variable "boot_volume_encryption_key" {
   default     = ""
   type        = string
 }
+
+variable "enable_pv_encryption_in_transit" {
+  description = "Whether to enable in-transit encryption for the data volume's paravirtualized attachment. The default value is false"
+  default = false
+  type = bool
+}


### PR DESCRIPTION
Closes #61 
Added support for the following:
1) Custom KMS Key support for Boot Volume encryption.
2) In-transit encryption for data volume's paravirtualized attachment.
