### PR TITLE
fix: updated operator_subnet_id refer to oci_core_vnic

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -10,7 +10,7 @@ output "operator_instance_principal_group_name" {
 }
 
 output "operator_subnet_id" {
-  value = data.oci_core_instance.operator.subnet_id
+  value = data.oci_core_vnic.operator_vnic.subnet_id
 }
 
 output "operator_nsg_id" {


### PR DESCRIPTION
- Terraform Warning
```
Warning: Deprecated attribute

on .terraform/modules/oke.operator/outputs.tf line 13, in output "operator_subnet_id":
13:   value = data.oci_core_instance.operator.subnet_id

The attribute "subnet_id" is deprecated. Refer to the provider documentation for details.
```

- LaunchInstanceDetails - subnetId

> Deprecated. Instead use subnetId in [CreateVnicDetails](https://docs.oracle.com/en-us/iaas/api/#/en/iaas/latest/CreateVnicDetails/). At least one of them is required; if you provide both, the values must match.