### PR TITLE
fix: Compartment AD listing, ignore lifecycle changes, resolve deprecation warning

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -39,10 +39,6 @@ resource "oci_core_instance" "operator" {
   }
 
   is_pv_encryption_in_transit_enabled = var.enable_pv_encryption_in_transit
-  # prevent the operator from destroying and recreating itself if the image ocid changes
-  lifecycle {
-    ignore_changes = [source_details[0].source_id]
-  }
 
   metadata = {
     ssh_authorized_keys = (var.ssh_public_key != "") ? var.ssh_public_key : (var.ssh_public_key_path != "none") ? file(var.ssh_public_key_path) : ""
@@ -66,6 +62,11 @@ resource "oci_core_instance" "operator" {
   }
 
   state = var.operator_state
+
+  # prevent the operator from destroying and recreating itself if the image ocid/tagging/user data changes
+  lifecycle {
+    ignore_changes = [freeform_tags, metadata["user_data"], source_details[0].source_id]
+  }
 
   timeouts {
     create = "60m"

--- a/datasources.tf
+++ b/datasources.tf
@@ -10,9 +10,8 @@ data "oci_core_services" "all_oci_services" {
 }
 
 data "oci_identity_availability_domain" "ad" {
-  compartment_id = var.tenancy_id
-
-  ad_number = var.availability_domain
+  compartment_id = var.compartment_id
+  ad_number      = var.availability_domain
 }
 
 data "oci_identity_tenancy" "tenancy" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,7 +10,7 @@ output "operator_instance_principal_group_name" {
 }
 
 output "operator_subnet_id" {
-  value = data.oci_core_instance.operator.subnet_id
+  value = oci_core_subnet.operator.id
 }
 
 output "operator_nsg_id" {

--- a/security.tf
+++ b/security.tf
@@ -61,6 +61,7 @@ resource "oci_core_security_list" "operator" {
   compartment_id = var.compartment_id
   display_name   = var.label_prefix == "none" ? "operator" : "${var.label_prefix}-operator"
   freeform_tags  = var.freeform_tags
+  vcn_id         = var.vcn_id
 
   # egress rule to the same subnet to allow users to use OCI Bastion service to connect to the operator
   egress_security_rules {
@@ -73,5 +74,7 @@ resource "oci_core_security_list" "operator" {
     }
   }
 
-  vcn_id = var.vcn_id
+  lifecycle {
+    ignore_changes = [freeform_tags]
+  }
 }

--- a/subnets.tf
+++ b/subnets.tf
@@ -11,4 +11,8 @@ resource "oci_core_subnet" "operator" {
   route_table_id             = var.nat_route_id
   security_list_ids          = [oci_core_security_list.operator.id]
   vcn_id                     = var.vcn_id
+
+  lifecycle {
+    ignore_changes = [freeform_tags]
+  }
 }


### PR DESCRIPTION
- Use specific compartment for AD listing in case different
- Ignore lifecycle changes for automatic tagging and rendered user_data
- Fix deprecation warning for operator_subnet_id

Closes #66.