### PR TITLE
fix: Ignore lifecycle changes for AD, defined_tags, all metadata

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -65,7 +65,7 @@ resource "oci_core_instance" "operator" {
 
   # prevent the operator from destroying and recreating itself if the image ocid/tagging/user data changes
   lifecycle {
-    ignore_changes = [freeform_tags, metadata["user_data"], source_details[0].source_id]
+    ignore_changes = [availability_domain, defined_tags, freeform_tags, metadata, source_details[0].source_id]
   }
 
   timeouts {


### PR DESCRIPTION
# Proposed changes
Ignore lifecycle changes reporting changes each apply:
* availability_domain
* defined_tags
* metadata

# Testing
Repeated apply and destroy yield no reported changes:
```
terraform apply
Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```
```
terraform apply
...
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```
```
terraform destroy
Plan: 0 to add, 0 to change, 3 to destroy.
Destroy complete! Resources: 3 destroyed.
```
```
terraform destroy
Destroy complete! Resources: 0 destroyed.
```