### PR TITLE
fix: Remove unrequired availability_domain from vnic_attachments data

### DIFF
--- a/datasources.tf
+++ b/datasources.tf
@@ -52,7 +52,6 @@ data "cloudinit_config" "operator" {
 
 # Gets a list of VNIC attachments on the operator instance
 data "oci_core_vnic_attachments" "operator_vnics_attachments" {
-  availability_domain = data.oci_identity_availability_domain.ad.name
   compartment_id      = var.compartment_id
   depends_on          = [oci_core_instance.operator]
   instance_id         = oci_core_instance.operator.id


### PR DESCRIPTION
The `availability_domain` parameter isn't required for `oci_core_vnic_attachments`, and a changed value currently yields an error on apply when trying to evaluate the data source, though the intention is to ignore lifecycle changes:

```
│ Error: Invalid index                                                                                                                                                                                     
│                                                                                                                                                                                                          
│   on .terraform/modules/operator/datasources.tf line 64, in data "oci_core_vnic" "operator_vnic":                                                                                                        
│   64:   vnic_id    = lookup(data.oci_core_vnic_attachments.operator_vnics_attachments.vnic_attachments[0], "vnic_id")                                          
│     ├────────────────                                                                                                                                                                                    
│     │ data.oci_core_vnic_attachments.operator_vnics_attachments.vnic_attachments is empty list of object                                                        
│                                                                                                    
│ The given key does not identify an element in this collection value: the collection has no elements.
```