### PR TITLE
fix: Add moved blocks for renamed dynamic group, policy

### DIFF
--- a/instance_principal.tf
+++ b/instance_principal.tf
@@ -41,3 +41,13 @@ resource "oci_identity_policy" "operator_group_policy" {
 
   count = var.enable_operator_instance_principal == true ? 1 : 0
 }
+
+moved {
+  from = oci_identity_policy.enable_operator_instance_principal
+  to = oci_identity_policy.operator_group_policy
+}
+
+moved {
+  from = oci_identity_dynamic_group.enable_operator_instance_principal
+  to = oci_identity_dynamic_group.operator_group
+}


### PR DESCRIPTION
Planned replacement after upgrade due to renamed resources:
```
Plan: 2 to add, 0 to change, 2 to destroy.
```
Handling with added `moved` blocks:
```
# oci_identity_dynamic_group.enable_operator_instance_principal[0] has moved to oci_identity_dynamic_group.operator_group[0]
resource "oci_identity_dynamic_group" "operator_group" {
    id             = "ocid1.dynamicgroup.oc1..aaa"
    name           = "dev-operator-instance-principal-aaa"
    # (7 unchanged attributes hidden)
}

# oci_identity_policy.enable_operator_instance_principal[0] has moved to oci_identity_policy.operator_group_policy[0]
resource "oci_identity_policy" "operator_group_policy" {
    id             = "ocid1.policy.oc1..aaa"
    name           = "dev-operator-instance-principal"
    # (10 unchanged attributes hidden)
}

Plan: 0 to add, 0 to change, 0 to destroy.
```

Repeated apply after move:
```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```