### PR TITLE
feat: Add assign_dns var to support disabled DNS

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -1,4 +1,4 @@
-# Copyright 2017, 2021 Oracle Corporation and/or affiliates.  All rights reserved.
+# Copyright 2017, 2022 Oracle Corporation and/or affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 resource "oci_core_instance" "operator" {
@@ -26,7 +26,7 @@ resource "oci_core_instance" "operator" {
   create_vnic_details {
     assign_public_ip = false
     display_name     = var.label_prefix == "none" ? "operator-vnic" : "${var.label_prefix}-operator-vnic"
-    hostname_label   = var.label_prefix == "none" ? "operator" : "${var.label_prefix}-operator"
+    hostname_label   = var.assign_dns ? var.label_prefix == "none" ? "operator" : "${var.label_prefix}-operator" : null
     nsg_ids          = concat(var.nsg_ids, [oci_core_network_security_group.operator.id])
     subnet_id        = oci_core_subnet.operator.id
   }

--- a/subnets.tf
+++ b/subnets.tf
@@ -1,11 +1,11 @@
-# Copyright 2017, 2021 Oracle Corporation and/or affiliates.  All rights reserved.
+# Copyright 2017, 2022 Oracle Corporation and/or affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 resource "oci_core_subnet" "operator" {
   cidr_block                 = local.operator_subnet
   compartment_id             = var.compartment_id
   display_name               = var.label_prefix == "none" ? "operator" : "${var.label_prefix}-operator"
-  dns_label                  = "operator"
+  dns_label                  = var.assign_dns ? "operator" : null
   freeform_tags              = var.freeform_tags
   prohibit_public_ip_on_vnic = true
   route_table_id             = var.nat_route_id
@@ -13,6 +13,6 @@ resource "oci_core_subnet" "operator" {
   vcn_id                     = var.vcn_id
 
   lifecycle {
-    ignore_changes = [freeform_tags]
+    ignore_changes = [dns_label, freeform_tags]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2021 Oracle Corporation and/or affiliates.  All rights reserved.
+# Copyright (c) 2019, 2022 Oracle Corporation and/or affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 # provider parameters
@@ -23,6 +23,12 @@ variable "label_prefix" {
 }
 
 # network parameters
+
+variable "assign_dns" {
+  default     = true
+  description = "Whether to assign DNS records for operator subnet"
+  type        = bool
+}
 
 variable "availability_domain" {
   description = "the AD to place the operator host"


### PR DESCRIPTION
## Proposed changes
* Subnet DNS label and instance hostname label cannot be defined when disabled on the VCN. This change adds the same `assign_dns` var used in the `terraform-oci-oke` module to enable operator creation in this configuration.
* Policy names must be unique within a compartment. Added a unique suffix to the operator instance principal policy name to prevent conflicts.